### PR TITLE
feat: add minimal habit tracker app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native';
+import HomeScreen from './src/screens/HomeScreen';
+import { AppStoreProvider } from './src/state/useAppStore';
+
+const App: React.FC = () => (
+  <AppStoreProvider>
+    <SafeAreaView style={{ flex: 1 }}>
+      <HomeScreen />
+    </SafeAreaView>
+  </AppStoreProvider>
+);
+
+export default App;

--- a/app.json
+++ b/app.json
@@ -1,0 +1,6 @@
+{
+  "expo": {
+    "name": "Habbit Tracker",
+    "slug": "HabbitTracker-App"
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,3 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+module.exports = getDefaultConfig(__dirname);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "HabbitTracker-App",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "@react-native-async-storage/async-storage": "^1.19.0",
+    "dayjs": "^1.11.10"
+  },
+  "devDependencies": {
+    "@types/react": "~18.0.0",
+    "@types/react-native": "~0.72.0",
+    "typescript": "^5.0.0"
+  },
+  "private": true
+}

--- a/src/components/HabitItem.tsx
+++ b/src/components/HabitItem.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, Switch } from 'react-native';
+
+interface Props {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+const HabitItem: React.FC<Props> = ({ label, checked, onToggle }) => {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 8 }}>
+      <Switch value={checked} onValueChange={onToggle} />
+      <Text style={{ marginLeft: 8 }}>{label}</Text>
+    </View>
+  );
+};
+
+export default HabitItem;

--- a/src/components/StreakCounter.tsx
+++ b/src/components/StreakCounter.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+interface Props {
+  streak: number;
+}
+
+const StreakCounter: React.FC<Props> = ({ streak }) => (
+  <View style={{ alignItems: 'center', marginVertical: 16 }}>
+    <Text style={{ fontSize: 32 }}>🔥 {streak}</Text>
+  </View>
+);
+
+export default StreakCounter;

--- a/src/constants/habits.ts
+++ b/src/constants/habits.ts
@@ -1,0 +1,17 @@
+import { Habit, HabitId } from '../utils/types';
+
+export const habits: Habit[] = [
+  { id: 'morning_mandarin', label: 'Morning Mandarin' },
+  { id: 'morning_workout', label: 'Morning Workout' },
+  { id: 'evening_mandarin', label: 'Evening Mandarin' },
+  { id: 'evening_workout', label: 'Evening Workout' },
+  { id: 'lab_hour', label: 'Lab Hour' },
+];
+
+export const allFalseHabitsState: Record<HabitId, boolean> = habits.reduce(
+  (acc, habit) => {
+    acc[habit.id] = false;
+    return acc;
+  },
+  {} as Record<HabitId, boolean>
+);

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,0 +1,1 @@
+export const APP_STATE = '@habbit_tracker/app_state';

--- a/src/hooks/useAppStateSync.ts
+++ b/src/hooks/useAppStateSync.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { useAppStore } from '../state/useAppStore';
+
+export const useAppStateSync = () => {
+  const { checkRollover } = useAppStore();
+
+  useEffect(() => {
+    checkRollover();
+    const sub = AppState.addEventListener('change', (status) => {
+      if (status === 'active') {
+        checkRollover();
+      }
+    });
+    const interval = setInterval(checkRollover, 60000);
+    return () => {
+      sub.remove();
+      clearInterval(interval);
+    };
+  }, [checkRollover]);
+};

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import { View, FlatList } from 'react-native';
+import StreakCounter from '../components/StreakCounter';
+import HabitItem from '../components/HabitItem';
+import { habits } from '../constants/habits';
+import { useAppStore } from '../state/useAppStore';
+import { useAppStateSync } from '../hooks/useAppStateSync';
+
+const HomeScreen: React.FC = () => {
+  const { state, toggleHabit, init } = useAppStore();
+  useAppStateSync();
+
+  useEffect(() => {
+    init();
+  }, [init]);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <StreakCounter streak={state.streak} />
+      <FlatList
+        data={habits}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <HabitItem
+            label={item.label}
+            checked={state.habits[item.id]}
+            onToggle={() => toggleHabit(item.id)}
+          />
+        )}
+      />
+    </View>
+  );
+};
+
+export default HomeScreen;

--- a/src/state/useAppStore.ts
+++ b/src/state/useAppStore.ts
@@ -1,0 +1,97 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  ReactNode,
+} from 'react';
+import { AppStateShape, HabitId } from '../utils/types';
+import { loadAppState, saveAppState } from '../utils/storage';
+import { allFalseHabitsState } from '../constants/habits';
+import { getTodayKey } from '../utils/date';
+
+interface AppStore {
+  state: AppStateShape;
+  toggleHabit: (id: HabitId) => void;
+  checkRollover: () => void;
+  init: () => Promise<void>;
+}
+
+const AppStoreContext = createContext<AppStore | undefined>(undefined);
+
+export const AppStoreProvider = ({ children }: { children: ReactNode }) => {
+  const [state, setState] = useState<AppStateShape>({
+    streak: 0,
+    currentDateKey: getTodayKey(),
+    habits: { ...allFalseHabitsState },
+    dayCompleted: false,
+  });
+
+  const persist = useCallback(async (newState: AppStateShape) => {
+    setState(newState);
+    await saveAppState(newState);
+  }, []);
+
+  const init = useCallback(async () => {
+    const stored = await loadAppState();
+    if (stored) {
+      setState(stored);
+    } else {
+      const fresh: AppStateShape = {
+        streak: 0,
+        currentDateKey: getTodayKey(),
+        habits: { ...allFalseHabitsState },
+        dayCompleted: false,
+      };
+      await saveAppState(fresh);
+      setState(fresh);
+    }
+  }, []);
+
+  const toggleHabit = useCallback(
+    (id: HabitId) => {
+      const updatedHabits = { ...state.habits, [id]: !state.habits[id] };
+      let { streak, dayCompleted } = state;
+      const allDone = Object.values(updatedHabits).every(Boolean);
+      if (allDone && !dayCompleted) {
+        streak += 1;
+        dayCompleted = true;
+      }
+      const newState: AppStateShape = {
+        ...state,
+        habits: updatedHabits,
+        streak,
+        dayCompleted,
+      };
+      persist(newState);
+    },
+    [state, persist]
+  );
+
+  const checkRollover = useCallback(() => {
+    const todayKey = getTodayKey();
+    if (state.currentDateKey !== todayKey) {
+      const newState: AppStateShape = {
+        ...state,
+        currentDateKey: todayKey,
+        habits: { ...allFalseHabitsState },
+        dayCompleted: false,
+      };
+      persist(newState);
+    }
+  }, [state, persist]);
+
+  return (
+    <AppStoreContext.Provider value={{ state, toggleHabit, checkRollover, init }}>
+      {children}
+    </AppStoreContext.Provider>
+  );
+};
+
+export const useAppStore = (): AppStore => {
+  const ctx = useContext(AppStoreContext);
+  if (!ctx) {
+    throw new Error('useAppStore must be used within AppStoreProvider');
+  }
+  return ctx;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,3 @@
+import dayjs from 'dayjs';
+
+export const getTodayKey = (): string => dayjs().format('YYYY-MM-DD');

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,22 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { APP_STATE } from '../constants/storageKeys';
+import { AppStateShape } from './types';
+
+export const loadAppState = async (): Promise<AppStateShape | null> => {
+  try {
+    const raw = await AsyncStorage.getItem(APP_STATE);
+    if (!raw) return null;
+    return JSON.parse(raw) as AppStateShape;
+  } catch (e) {
+    console.warn('Failed to load app state', e);
+    return null;
+  }
+};
+
+export const saveAppState = async (state: AppStateShape): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(APP_STATE, JSON.stringify(state));
+  } catch (e) {
+    console.warn('Failed to save app state', e);
+  }
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,15 @@
+export type HabitId =
+  | 'morning_mandarin'
+  | 'morning_workout'
+  | 'evening_mandarin'
+  | 'evening_workout'
+  | 'lab_hour';
+
+export type Habit = { id: HabitId; label: string };
+
+export type AppStateShape = {
+  streak: number;
+  currentDateKey: string;
+  habits: Record<HabitId, boolean>;
+  dayCompleted: boolean;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Expo + TypeScript habit tracker
- persist habits and streak to AsyncStorage
- handle daily rollover and streak updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68afc4c0188c8330b37ed1fa2568b09d