### PR TITLE
fix(insights): remove VictoryTheme/material usage, add data guards, inline chart styles for victory-native XL

### DIFF
--- a/src/screens/InsightsScreen.tsx
+++ b/src/screens/InsightsScreen.tsx
@@ -5,10 +5,9 @@ import {
   VictoryChart,
   VictoryBar,
   VictoryAxis,
-  VictoryTheme,
-  // VictoryGroup,
-  // VictoryLine,
-  // VictoryTooltip,
+  VictoryGroup,
+  VictoryLine,
+  VictoryTooltip,
 } from 'victory-native';
 import { getHabitsV2, getLogsByDateV2 } from '../services/storageV2';
 import { HabitV2 } from '../types/v2';
@@ -17,6 +16,15 @@ import Screen from '../components/Screen';
 import { useHabitsV2 } from '../hooks/useHabitsV2';
 import { palette } from '../theme/palette';
 import { metrics } from '../theme/metrics';
+
+// util to coerce/clean chart data
+const toNumber = (v: any) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+const safeData = <T extends { x?: any; y?: any }>(arr: T[] | undefined | null) =>
+  Array.isArray(arr)
+    ? arr
+        .filter((d) => d && d.x !== undefined && d.y !== undefined)
+        .map((d) => ({ x: d.x, y: toNumber(d.y) }))
+    : [];
 
 type Totals = { [habitId: string]: number };
 type BadgeCounts = { [habitId: string]: Record<string, number> };
@@ -57,12 +65,23 @@ export default function InsightsScreen() {
     })();
   }, [mode]);
 
-  const data = habits.map(h => ({ habit: h.name, minutes: totals[h.habitId] ?? 0 }));
-  const safeData = (arr: { habit: any; minutes: any }[]) =>
-    (Array.isArray(arr) ? arr : [])
-      .map(d => ({ x: d.habit, y: Number(d.minutes) }))
-      .filter(d => d && d.x != null && Number.isFinite(d.y));
-  const chartData = safeData(data);
+  const weekRaw = habits.map((h) => ({ x: h.name, y: totals[h.habitId] ?? 0 }));
+  const monthRaw: typeof weekRaw = [];
+  const weekData = safeData(weekRaw);
+  const monthData = safeData(monthRaw);
+
+  if (!weekData.length && !monthData.length) {
+    return (
+      <Screen style={styles.container}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+          <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8 }}>No insights yet</Text>
+          <Text style={{ opacity: 0.7, textAlign: 'center' }}>
+            Complete a habit to see your progress here.
+          </Text>
+        </View>
+      </Screen>
+    );
+  }
 
   return (
     <Screen style={styles.container}>
@@ -74,14 +93,66 @@ export default function InsightsScreen() {
         </View>
       </View>
       <Text style={styles.row}>Overall streak: {overall} day(s)</Text>
-      {chartData.length > 0 ? (
-        <VictoryChart theme={VictoryTheme?.material ?? undefined} domainPadding={20}>
-          <VictoryAxis style={{ tickLabels: { angle: 45, fill: '#cbd5e1', fontSize: 10 } }} />
-          <VictoryAxis dependentAxis style={{ tickLabels: { fill: '#cbd5e1' } }} tickFormat={(t: any) => `${t}m`} />
-          <VictoryBar data={chartData} style={{ data: { fill: '#4f46e5' } }} />
+      <VictoryChart
+        domainPadding={{ x: 24, y: 12 }}
+        padding={{ top: 24, bottom: 48, left: 48, right: 24 }}
+      >
+        <VictoryAxis
+          style={{
+            axis: { stroke: '#e2e8f0' },
+            tickLabels: { fontSize: 12, padding: 6, fill: '#64748b' },
+            grid: { stroke: '#f1f5f9' },
+          }}
+        />
+        <VictoryAxis
+          dependentAxis
+          style={{
+            axis: { stroke: '#e2e8f0' },
+            tickLabels: { fontSize: 12, padding: 4, fill: '#64748b' },
+            grid: { stroke: '#f1f5f9' },
+          }}
+        />
+        <VictoryGroup>
+          <VictoryBar
+            data={weekData}
+            labels={({ datum }: any) => `${datum.y}`}
+            labelComponent={<VictoryTooltip constrainToVisibleArea />}
+            style={{
+              data: { opacity: 0.9, borderRadius: 4 },
+              labels: { fontSize: 10 },
+            }}
+            barWidth={({ index }: any) => 16}
+          />
+        </VictoryGroup>
+      </VictoryChart>
+
+      {/* Optional trend line over month data */}
+      {monthData.length > 0 && (
+        <VictoryChart
+          domainPadding={{ x: 12, y: 8 }}
+          padding={{ top: 24, bottom: 48, left: 48, right: 24 }}
+        >
+          <VictoryAxis
+            style={{
+              axis: { stroke: '#e2e8f0' },
+              tickLabels: { fontSize: 12, padding: 6, fill: '#64748b' },
+              grid: { stroke: '#f1f5f9' },
+            }}
+          />
+          <VictoryAxis
+            dependentAxis
+            style={{
+              axis: { stroke: '#e2e8f0' },
+              tickLabels: { fontSize: 12, padding: 4, fill: '#64748b' },
+              grid: { stroke: '#f1f5f9' },
+            }}
+          />
+          <VictoryLine
+            data={monthData}
+            interpolation="monotoneX"
+            style={{ data: { strokeWidth: 2 } }}
+          />
         </VictoryChart>
-      ) : (
-        <Text style={styles.empty}>No time tracked yet.</Text>
       )}
 
       <View style={styles.section}>
@@ -118,7 +189,6 @@ const styles = StyleSheet.create({
   },
   sectionTitle: { color: palette.textDim, fontSize: 14, marginBottom: metrics.gap, letterSpacing: 0.5 },
   row: { color: palette.text, marginBottom: 6 },
-  empty: { color: palette.textDim },
   pill: { paddingVertical: 6, paddingHorizontal: 10, borderWidth: 1, borderColor: palette.border, borderRadius: 999 },
   pillActive: { backgroundColor: palette.card },
   pillText: { color: palette.text },

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -1,5 +1,9 @@
 declare module 'victory-native' {
-  const VictoryNative: any;
-  export = VictoryNative;
+  export const VictoryChart: any;
+  export const VictoryBar: any;
+  export const VictoryAxis: any;
+  export const VictoryGroup: any;
+  export const VictoryLine: any;
+  export const VictoryTooltip: any;
 }
 


### PR DESCRIPTION
## Summary
- replace VictoryTheme/material usage with inline styles and sanitize chart data
- add defensive empty state and typed shims for victory-native

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b73c4a68788330b57b5fde6d45a1d0